### PR TITLE
Workaround for bad optionName which does not exist. Some searching ab…

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -1013,6 +1013,11 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             int level      = context.RequestData.ReadInt32();
             int optionName = context.RequestData.ReadInt32();
 
+            if (optionName == 16384)
+            {
+                optionName = 4098;
+            }
+
             (ulong bufferPos, ulong bufferSize) = context.Request.GetBufferType0x21();
 
             LinuxError errno  = LinuxError.EBADF;


### PR DESCRIPTION
…out relates the value it gets with ReceiveBuffer so I just subbed it in for a workaround for now and it happens to work