### PR TITLE
Allow to start Ryujinx in wayland environment (#3516)

### DIFF
--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -148,10 +148,10 @@ namespace Ryujinx.Ui
 
             // Apply custom theme if needed.
             ThemeHelper.ApplyTheme();
-
+            Gdk.Monitor monitor = Display.GetMonitor(0);
             // Sets overridden fields.
-            int monitorWidth  = Display.PrimaryMonitor.Geometry.Width  * Display.PrimaryMonitor.ScaleFactor;
-            int monitorHeight = Display.PrimaryMonitor.Geometry.Height * Display.PrimaryMonitor.ScaleFactor;
+            int monitorWidth  = monitor.Geometry.Width  * monitor.ScaleFactor;
+            int monitorHeight = monitor.Geometry.Height * monitor.ScaleFactor;
 
             DefaultWidth  = monitorWidth  < 1280 ? monitorWidth  : 1280;
             DefaultHeight = monitorHeight < 760  ? monitorHeight : 760;


### PR DESCRIPTION
PrimaryMonitor is only available on X11

At some point it will be deprecated, this change support wayland